### PR TITLE
Various fixes and enhancements

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -62,4 +62,12 @@ function graphql(query) {
   }
 }
 
-module.exports = { $, $$, exit, graphql };
+function toArray(listString) {
+  if (!listString) {
+    return [];
+  }
+
+  return listString.split(/\r?\n/);
+}
+
+module.exports = { $, $$, exit, graphql, toArray };

--- a/merge-pull-request.js
+++ b/merge-pull-request.js
@@ -16,7 +16,7 @@ function mergePullRequest(prId, remote = "origin") {
   ensureHub();
 
   const separator = '|';
-  const rawResults = $(`hub pr list -f "%I${separator}%B${separator}%H${separator}%U${separator}%sH"`);
+  const rawResults = $(`hub pr list -f "%I${separator}%B${separator}%H${separator}%U${separator}%sH%n"`);
   
   const results = rawResults.split(EOL).map(line => {
     const [id, baseBranch, headBranch, url, sha] = line.split(separator);

--- a/repo.js
+++ b/repo.js
@@ -44,7 +44,7 @@ branchProtectionRules(first: 3) {
 }
 
 let info;
-function getRepoInfo() {
+function getRepoInfo(releaseVersion = null) {
   if (typeof info === 'object') {
     return info;
   }
@@ -52,13 +52,17 @@ function getRepoInfo() {
   ensureHub();
 
   const { packageVersion, versionPrefix, commitMessage } = getEnvironment();
-  const releaseBranch = `release/${packageVersion}`;
-  const prTitle = commitMessage.replace(/%s/g, packageVersion);
+  if (releaseVersion === null) {
+    releaseVersion = packageVersion;
+  }
+
+  const releaseBranch = `release/${releaseVersion}`;
+  const prTitle = commitMessage.replace(/%s/g, releaseVersion);
 
   const defaultBranch = getDefaultBranch();
   const productionBranch = determineProductionBranch();
 
-  const milestone = `${versionPrefix}${packageVersion}`;
+  const milestone = `${versionPrefix}${releaseVersion}`;
   ensureMilestone(milestone);
 
   const remote = "origin"; // TODO

--- a/repo.js
+++ b/repo.js
@@ -108,7 +108,13 @@ function ensureNoOtherBumps(remote, defaultBranch, productionBranch) {
   if (unmergedProductionBranches.length > 0) {
     exit(`another version bump is in progress - found unmerged production branches: ${unmergedProductionBranches.join(", ")}`);
   }
-
 }
 
-module.exports = { getRepoInfo, ensureSynchronized, ensureNoOtherBumps, getDefaultBranch };
+function ensureUnreleased(releaseVersion, defaultBranch) {
+  const mergedTags = toArray($(`git tag --list '${releaseVersion}' --merged ${defaultBranch}`));
+  if (mergedTags.length > 0) {
+    exit(`version already released - found merged tags: ${mergedTags.join(", ")}`);
+  }
+}
+
+module.exports = { getRepoInfo, ensureSynchronized, ensureNoOtherBumps, ensureUnreleased, getDefaultBranch };

--- a/repo.js
+++ b/repo.js
@@ -61,7 +61,9 @@ function getRepoInfo() {
   const milestone = `${versionPrefix}${packageVersion}`;
   ensureMilestone(milestone);
 
-  info = { milestone, releaseBranch, prTitle, defaultBranch, productionBranch };
+  const remote = "origin"; // TODO
+
+  info = { remote, milestone, releaseBranch, prTitle, defaultBranch, productionBranch };
   return info;
 }
 

--- a/repo.js
+++ b/repo.js
@@ -15,7 +15,17 @@ function getDefaultBranch() {
 
 function determineProductionBranch() {
   const defaultBranch = getDefaultBranch();
-  const branches = graphql('protectedBranches(first: 3) { nodes { name } }').protectedBranches.nodes;
+const branches = graphql(`
+branchProtectionRules(first: 3) {
+  nodes {
+    matchingRefs(first: 2) {
+      nodes {
+        name
+      }
+    }
+  }
+}`).branchProtectionRules.nodes.flatMap(node => node.matchingRefs.nodes);
+
 
   if (branches.length !== 2) {
     exit(`expected two protected branches but found ${branches.length}`);
@@ -29,7 +39,7 @@ function determineProductionBranch() {
     case secondBranch:
       return firstBranch;
     default:
-      return exit('could not determine production branch because neither protected branch mataches the default branch');
+      return exit('could not determine production branch because neither protected branch matches the default branch');
   }
 }
 

--- a/run-mergeversion
+++ b/run-mergeversion
@@ -6,7 +6,9 @@ const { $, $$, exit } = require('./helpers');
 const { getRepoInfo } = require('./repo');
 const mergePullRequest = require('./merge-pull-request');
 
-const { remote, releaseBranch, productionBranch, prTitle, defaultBranch, milestone } = getRepoInfo();
+const [/*node*/, /*file*/, releaseVersion] = process.argv
+
+const { remote, releaseBranch, productionBranch, prTitle, defaultBranch, milestone } = getRepoInfo(releaseVersion);
 
 // find current pull request for version release
 const rawResults = $(`hub pr list --head ${releaseBranch} --base ${productionBranch} -f "%I"`);

--- a/run-mergeversion
+++ b/run-mergeversion
@@ -6,7 +6,7 @@ const { $, $$, exit } = require('./helpers');
 const { getRepoInfo } = require('./repo');
 const mergePullRequest = require('./merge-pull-request');
 
-const { releaseBranch, productionBranch, prTitle, defaultBranch, milestone } = getRepoInfo();
+const { remote, releaseBranch, productionBranch, prTitle, defaultBranch, milestone } = getRepoInfo();
 
 // find current pull request for version release
 const rawResults = $(`hub pr list --head ${releaseBranch} --base ${productionBranch} -f "%I"`);
@@ -23,6 +23,6 @@ mergePullRequest(prId);
 // update/create release branch to match production branch
 $$(`hub checkout -B ${releaseBranch} ${productionBranch}`);
 // re-publish version branch
-$$(`hub push --follow-tags --set-upstream origin ${releaseBranch}`);
+$$(`hub push --follow-tags --set-upstream ${remote} ${releaseBranch}`);
 // create pull request to merge production commits into default branch
 $$(`hub pull-request --no-edit --message "${prTitle}" --base "${defaultBranch}" --milestone "${milestone}"`);

--- a/run-mergeversion
+++ b/run-mergeversion
@@ -7,6 +7,9 @@ const { getRepoInfo } = require('./repo');
 const mergePullRequest = require('./merge-pull-request');
 
 const [/*node*/, /*file*/, releaseVersion] = process.argv
+if (!releaseVersion) {
+  exit(`release version is required`)
+}
 
 const { remote, releaseBranch, productionBranch, prTitle, defaultBranch, milestone } = getRepoInfo(releaseVersion);
 

--- a/run-postversion
+++ b/run-postversion
@@ -3,9 +3,9 @@
 const { $$ } = require('./helpers');
 const { getRepoInfo } = require('./repo');
 
-const { releaseBranch, prTitle, productionBranch, milestone } = getRepoInfo();
+const { remote, releaseBranch, prTitle, productionBranch, milestone } = getRepoInfo();
 
 // publish branch
-$$(`hub push --follow-tags --set-upstream origin ${releaseBranch}`);
+$$(`hub push --follow-tags --set-upstream ${remote} ${releaseBranch}`);
 // create pull request
 $$(`hub pull-request --no-edit --message "${prTitle}" --base "${productionBranch}" --milestone "${milestone}"`);

--- a/run-preversion
+++ b/run-preversion
@@ -1,9 +1,9 @@
 #! /usr/bin/env node
 
 const { $$ } = require('./helpers');
-const { getRepoInfo, ensureSynchronized } = require('./repo');
+const { getRepoInfo, ensureSynchronized, ensureNoOtherBumps } = require('./repo');
 
-const { defaultBranch } = getRepoInfo();
+const { remote, defaultBranch, productionBranch } = getRepoInfo();
 
 // checkout development branch
 $$(`hub checkout ${defaultBranch}`);
@@ -11,5 +11,7 @@ $$(`hub checkout ${defaultBranch}`);
 $$(`hub sync`);
 // ensure local and remote head branch are in sync (`hub sync` only warns)
 ensureSynchronized();
+// ensure no other version bumps are in progress (unmerged tags or release branches)
+ensureNoOtherBumps(remote, defaultBranch, productionBranch);
 // run test suite
 $$(`npm test`);

--- a/run-version
+++ b/run-version
@@ -2,13 +2,15 @@
 
 const { $$ } = require('./helpers');
 const { getEnvironment } = require('./environment');
-const { getRepoInfo } = require('./repo');
+const { getRepoInfo, ensureUnreleased } = require('./repo');
 
-const { packageVersion } = getEnvironment();
-const { releaseBranch } = getRepoInfo();
+const { versionPrefix, packageVersion } = getEnvironment();
+const { releaseBranch, defaultBranch } = getRepoInfo();
 
 const bumpPlugin = `@jarrodldavis/changelog-version-bump=version:'${packageVersion}'`;
 
+// ensure new version hasn't already been released
+ensureUnreleased(`${versionPrefix}${packageVersion}`, defaultBranch);
 // create new release branch
 $$(`hub checkout -b ${releaseBranch}`);
 // update changelog with new version


### PR DESCRIPTION
- [x] Update GraphQL query for protected branch rules since the previous API has been removed
- [x] Centralize assumption of `origin` as the remote repo name
- [x] Add additional error checking to ensure no other version bumps are in progress and that the "new" version hasn't already been relesed
- [x] Fix `run-mergeversion` to require an argument so it can be run from any branch
- [x] Fix the formatting of `hub pr list` so that correct information is retrieved when multiple pull requests are open